### PR TITLE
feat: export tools such as replaceInFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"
+    },
+    "./tools": {
+      "types": "./dist/tools/index.d.ts",
+      "import": "./dist/tools/index.mjs"
     }
   },
   "main": "./dist/index.mjs",

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Export some dependencies of scaffold from this directory to make it easier for the user to invoke
+ *
+ */
+import fse from "fs-extra";
+import { replaceInFile, replaceInFileSync } from "replace-in-file";
+
+export { replaceInFile, replaceInFileSync, fse };


### PR DESCRIPTION
Re-export some scaffold dependency packages to make it easier for scaffold users to reuse them.

(Users don't need to install them again)

The export path is `zotero-plugin-scaffold/tools`, for example:

```ts
import { replaceInFileSync } from "zotero-plugin-scaffold/tools";

export default defineConfig({
  build: {
    assets: ["addon/**/*.*"],
    define: {
      ...pkg.config,
    },
    esbuildOptions: [
      {
        entryPoints: ["src/index.ts"],
        define: {
          __env__: `"${process.env.NODE_ENV}"`,
        },
        bundle: true,
        target: "firefox115",
        outfile: `build/addon/chrome/content/scripts/${pkg.config.addonRef}.js`,
      },
    ],
    hooks: {
      "build:makeUpdateJSON": (ctx) => {
        replaceInFileSync( /** option */) 
      },
    },
  },
});
```

---

Currently only exporting `replaceInFile` and `fs-extra`, I'm not sure if I need to export the rest of the package, or even split out some of the methods in `Build`.
