### PR TITLE
fix(tester): miss deps on Utuntu 24

### DIFF
--- a/src/core/tester.ts
+++ b/src/core/tester.ts
@@ -8,7 +8,7 @@ import { isCI } from "std-env";
 import { glob } from "tinyglobby";
 import { Xvfb } from "xvfb-ts";
 import { saveResource } from "../utils/file.js";
-import { installXvfb, installZoteroLinux } from "../utils/headless.js";
+import { installDepsForUbuntu24, installXvfb, installZoteroLinux } from "../utils/headless.js";
 import { toArray } from "../utils/string.js";
 import { ZoteroRunner } from "../utils/zotero-runner.js";
 import { findFreeTcpPort } from "../utils/zotero/remote-zotero.js";
@@ -547,14 +547,14 @@ export default class Test extends Base {
   async startZoteroHeadless() {
     // Ensure xvfb installing
     await installXvfb();
+    await installDepsForUbuntu24();
 
     // Download and Extract Zotero Beta Linux
     await installZoteroLinux();
 
-    // Set Environment Variable for Zotero Bin Path
-    process.env.ZOTERO_PLUGIN_ZOTERO_BIN_PATH = `${cwd()}/Zotero_linux-x86_64/zotero`;
-
-    const xvfb = new Xvfb();
+    const xvfb = new Xvfb({
+      timeout: 2000,
+    });
     await xvfb.start();
     await this.startZotero();
   }

--- a/src/core/tester.ts
+++ b/src/core/tester.ts
@@ -554,9 +554,7 @@ export default class Test extends Base {
     // Set Environment Variable for Zotero Bin Path
     process.env.ZOTERO_PLUGIN_ZOTERO_BIN_PATH = `${cwd()}/Zotero_linux-x86_64/zotero`;
 
-    const xvfb = new Xvfb({
-      timeout: 2000,
-    });
+    const xvfb = new Xvfb();
     await xvfb.start();
     await this.startZotero();
   }

--- a/src/utils/headless.ts
+++ b/src/utils/headless.ts
@@ -17,7 +17,7 @@ export async function installXvfb() {
       const osId = execSync("cat /etc/os-release | grep '^ID='").toString();
       if (osId.includes("ubuntu") || osId.includes("debian")) {
         logger.debug("Detected Ubuntu/Debian. Installing Xvfb...");
-        execSync("sudo apt-get update && sudo apt-get install -y xvfb", { stdio: "pipe" });
+        execSync("sudo apt-get update && sudo apt-get install -y xvfb", { stdio: "inherit" });
       }
       else if (osId.includes("centos") || osId.includes("rhel")) {
         logger.debug("Detected CentOS/RHEL. Installing Xvfb...");

--- a/src/utils/headless.ts
+++ b/src/utils/headless.ts
@@ -1,48 +1,71 @@
 import { execSync } from "node:child_process";
 import process from "node:process";
-import { isLinux } from "std-env";
-import { logger } from "./log.js";
+import { isDebug, isLinux } from "std-env";
+import { LOG_LEVEL, logger } from "./log.js";
 
-export async function installXvfb() {
-  logger.debug("Installing xvfb...");
-  if (!isLinux) {
-    logger.error("Unsupported platform. Please install Xvfb manually.");
-    process.exit(1);
-  }
+function isPackageInstalled(packageName: string): boolean {
   try {
-    execSync("which xvfb", { stdio: "inherit" });
+    execSync(`dpkg-query -W ${packageName}`, { stdio: "ignore" });
+    return true;
   }
   catch {
-    try {
-      const osId = execSync("cat /etc/os-release | grep '^ID='").toString();
-      if (osId.includes("ubuntu") || osId.includes("debian")) {
-        logger.debug("Detected Ubuntu/Debian. Installing Xvfb...");
-        execSync("sudo apt-get update && sudo apt-get install -y xvfb", { stdio: "inherit" });
-      }
-      else if (osId.includes("centos") || osId.includes("rhel")) {
-        logger.debug("Detected CentOS/RHEL. Installing Xvfb...");
-        execSync("sudo yum install -y xorg-x11-server-Xvfb", { stdio: "pipe" });
-      }
-      else {
-        throw new Error("Unsupported Linux distribution.");
-      }
-      logger.debug("Xvfb installation completed.");
-    }
-    catch (error) {
-      logger.error("Failed to install Xvfb:", error);
-      process.exit(1);
-    }
+    return false;
   }
 }
 
-export async function installZoteroLinux() {
-  logger.debug("Installing Zotero...");
+function installPackage(packageName: string): void {
+  const debug = isDebug || logger.level <= LOG_LEVEL.debug;
   try {
-    execSync("wget -O zotero.tar.bz2 'https://www.zotero.org/download/client/dl?platform=linux-x86_64&channel=beta'", { stdio: "pipe" });
-    execSync("tar -xvf zotero.tar.bz2", { stdio: "pipe" });
+    logger.debug(`Installing ${packageName}...`);
+    execSync(`sudo apt update && sudo apt install -y ${packageName}`, { stdio: debug ? "inherit" : "pipe" });
+    logger.debug(`${packageName} installed successfully.`);
   }
-  catch (e) {
-    logger.error(e);
-    throw new Error("Zotero extracted failed");
+  catch (error) {
+    logger.fail(`Failed to install ${packageName}.`, error);
+    throw error;
   }
+}
+
+function checkAndInstallDependencies(packages: string[]): void {
+  packages.forEach((pkg) => {
+    if (isPackageInstalled(pkg)) {
+      logger.debug(`${pkg} is already installed.`);
+    }
+    else {
+      installPackage(pkg);
+    }
+  });
+}
+
+export async function installXvfb() {
+  if (!isLinux) {
+    logger.error("Unsupported platform. Please install Xvfb manually.");
+    return;
+  }
+
+  const osId = execSync("cat /etc/os-release | grep '^ID='").toString();
+  if (!(osId.includes("ubuntu") || osId.includes("debian"))) {
+    logger.error("Unsupported Linux distribution.");
+    return;
+  }
+
+  checkAndInstallDependencies(["xvfb", "x11-xkb-utils", "xkb-data"]);
+}
+
+export async function installDepsForUbuntu24() {
+  checkAndInstallDependencies(["libasound2t64", "libdbus-glib-1-2"]);
+}
+
+export async function installZoteroLinux() {
+  if (process.env.ZOTERO_PLUGIN_ZOTERO_BIN_PATH) {
+    logger.debug("Local Zotero found, skip to download.");
+    return;
+  }
+
+  logger.debug("Installing Zotero...");
+  execSync("wget -O zotero.tar.bz2 'https://www.zotero.org/download/client/dl?platform=linux-x86_64&channel=beta'", { stdio: "pipe" });
+  execSync("tar -xvf zotero.tar.bz2", { stdio: "pipe" });
+
+  // Set Environment Variable for Zotero Bin Path
+  process.env.ZOTERO_PLUGIN_ZOTERO_BIN_PATH = `${process.cwd()}/Zotero_linux-x86_64/zotero`;
 }

--- a/src/utils/headless.ts
+++ b/src/utils/headless.ts
@@ -10,7 +10,7 @@ export async function installXvfb() {
     process.exit(1);
   }
   try {
-    execSync("which xvfb", { stdio: "ignore" });
+    execSync("which xvfb", { stdio: "inherit" });
   }
   catch {
     try {

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -45,6 +45,10 @@ export class Log {
     this.logLevel = LOG_LEVEL[level];
   }
 
+  get level() {
+    return this.logLevel;
+  }
+
   private formatArgs(arg: any): string {
     if (typeof arg === "string")
       return arg;

--- a/src/utils/zotero-runner.ts
+++ b/src/utils/zotero-runner.ts
@@ -117,6 +117,8 @@ export class ZoteroRunner {
     const remotePort = await findFreeTcpPort();
     args.push("-start-debugger-server", String(remotePort));
 
+    logger.debug("Zotero start args: ", args);
+
     const env = {
       ...process.env,
       XPCOM_DEBUG_BREAK: "stack",
@@ -126,10 +128,12 @@ export class ZoteroRunner {
     // Using `spawn` so we can stream logging as they come in, rather than
     // buffer them up until the end, which can easily hit the max buffer size.
     this.zotero = spawn(this.options.binaryPath, args, { env });
+    logger.debug("Zotero started, pid:", this.zotero.pid);
 
     // Handle Zotero log, necessary on macOS
     this.zotero.stdout?.on("data", (_data) => {});
 
+    logger.debug("Connecting to the remote Firefox debugger...");
     await this.remoteFirefox.connect(remotePort);
     logger.debug(`Connected to the remote Firefox debugger on port: ${remotePort}`);
   }

--- a/src/utils/zotero/remote-zotero.ts
+++ b/src/utils/zotero/remote-zotero.ts
@@ -84,7 +84,7 @@ export class RemoteFirefox {
         return this.client;
       }
       catch (error: any) {
-        logger.debug("Connecte to remote Zotero failed: ", error);
+        logger.fail('Failed to connecte to RDP client, retry...')
         if (isErrorWithCode("ECONNREFUSED", error)) {
           await new Promise(resolve => setTimeout(resolve, RETRY_INTERVAL));
           lastError = error;

--- a/src/utils/zotero/remote-zotero.ts
+++ b/src/utils/zotero/remote-zotero.ts
@@ -84,6 +84,7 @@ export class RemoteFirefox {
         return this.client;
       }
       catch (error: any) {
+        logger.debug("Connecte to remote Zotero failed: ", error);
         if (isErrorWithCode("ECONNREFUSED", error)) {
           await new Promise(resolve => setTimeout(resolve, RETRY_INTERVAL));
           lastError = error;


### PR DESCRIPTION
closes: #74 

![PixPin_2024-12-18_20-44-13](https://github.com/user-attachments/assets/3c056db0-a416-4f30-974c-c3c1b38538f8)

![PixPin_2024-12-18_20-44-29](https://github.com/user-attachments/assets/9a7a8a50-95b3-400a-825f-d57881a07e97)

Zotero has a missing dependency on Ubuntu 24.04 that prevents it from starting, so the Test module fails to start.

This PR adds a way to check for these dependencies and adds more debugging logs for key locations.