### PR TITLE
fix: better logs for prefixing prefs key and data-i10n-id

### DIFF
--- a/packages/scaffold/src/core/builder.ts
+++ b/packages/scaffold/src/core/builder.ts
@@ -184,7 +184,7 @@ export default class Build extends Base {
         // rename *.ftl to addonRef-*.ftl
         if (build.fluent.prefixLocaleFiles === true) {
           await move(ftlPath, `${dirname(ftlPath)}/${namespace}-${basename(ftlPath)}`);
-          this.logger.debug(`FTL file '${ftlPath}' is renamed to '${namespace}-${basename(ftlPath)}'`);
+          this.logger.debug(`FTL file '${ftlPath}' is renamed to '${namespace}-${basename(ftlPath)}'.`);
         }
       }));
 
@@ -205,14 +205,14 @@ export default class Build extends Base {
         const [matched, attrKey, attrVal] = match;
 
         if (!allMessages.has(attrVal)) {
-          this.logger.debug(`HTML data-i10n-id ${chalk.blue(attrVal)} in ${chalk.gray(htmlPath)} do not exist in any FTL message, skip to namespace it.`);
+          this.logger.warn(`HTML data-i10n-id '${chalk.blue(attrVal)}' in ${chalk.gray(htmlPath)} do not exist in any FTL message, skip to namespace it.`);
           continue;
         }
 
         messagesInHTML.add(attrVal);
         const namespacedAttr = `${namespace}-${attrVal}`;
         htmlContent = htmlContent.replace(matched, `${attrKey}="${namespacedAttr}"`);
-        this.logger.debug(`HTML data-i10n-id ${chalk.blue(attrVal)} in ${chalk.gray(htmlPath)} is namespaced to ${chalk.blue(namespacedAttr)}`);
+        this.logger.debug(`HTML data-i10n-id '${chalk.blue(attrVal)}' in ${chalk.gray(htmlPath)} is namespaced to ${chalk.blue(namespacedAttr)}.`);
       }
 
       if (build.fluent.prefixFluentMessages)
@@ -220,11 +220,11 @@ export default class Build extends Base {
     }));
 
     // Check miss 1: Cross check in diff locale - seems no need
-    // messagesMap.forEach((messageInThisLang, lang) => {
+    // messagesByLocale.forEach((messageInThisLang, lang) => {
     //   // Needs Nodejs 22
     //   const diff = allMessages.difference(messageInThisLang);
     //   if (diff.size)
-    //     this.logger.warn(`FTL messages "${Array.from(diff).join(", ")} don't exist the locale ${lang}"`);
+    //     this.logger.warn(`FTL messages '${Array.from(diff).join(", ")}' don't exist the locale '${lang}'`);
     // });
 
     // Check miss 2: Check ids in HTML but not in ftl
@@ -234,7 +234,7 @@ export default class Build extends Base {
         .map(([locale]) => locale);
 
       if (missingLocales.length > 0) {
-        this.logger.warn(`HTML data-l10n-id "${chalk.blue(messageInHTML)}" is missing in locales: ${missingLocales.join(", ")}`);
+        this.logger.warn(`HTML data-l10n-id '${chalk.blue(messageInHTML)}' is missing in locales: ${missingLocales.join(", ")}.`);
       }
     });
   }

--- a/packages/scaffold/src/core/builder.ts
+++ b/packages/scaffold/src/core/builder.ts
@@ -281,6 +281,7 @@ export default class Build extends Base {
           const [matched, key] = match;
           if (!(key in prefsWithoutPrefix) && !(key in prefsWithoutPrefix)) {
             this.logger.warn(`preference key '${key}' in ${path.replace(`${dist}/`, "")} not init in prefs.js`);
+            content = content.replace(matched, `preference="${prefix}.${key}"`);
             continue;
           }
           if (key.startsWith(prefix)) {

--- a/packages/scaffold/src/utils/prefs-manager.ts
+++ b/packages/scaffold/src/utils/prefs-manager.ts
@@ -55,7 +55,7 @@ export class PrefsManager {
     const content = this.render();
     // console.log(content);
     await outputFile(path, content, "utf-8");
-    logger.debug("The <profile>/prefs.js has been modified.");
+    logger.debug("The prefs.js has been modified.");
   }
 
   setPref(key: string, value: any) {


### PR DESCRIPTION
The preferences will be filtered if not initialized in `prefs.js`. The prefix will not be added to these preferences in `preferences.xhtml` after building, resulting in these settings will not be correctly recognized, even if they are manually assigned.