### PR TITLE
refactor: migrate to `@fluent/syntax`

### DIFF
--- a/packages/scaffold/package.json
+++ b/packages/scaffold/package.json
@@ -69,6 +69,7 @@
     }
   },
   "dependencies": {
+    "@fluent/syntax": "^0.19.0",
     "@swc/core": "^1.11.16",
     "adm-zip": "^0.5.16",
     "bumpp": "^10.1.0",

--- a/packages/scaffold/src/core/builder/fluent.ts
+++ b/packages/scaffold/src/core/builder/fluent.ts
@@ -172,17 +172,25 @@ export class MessageManager {
     }
   }
 
-  // Validate that all HTML messages exist in all FTL locales
   validateMessages() {
+    // Check miss 1: Cross check in diff locale - seems no need
+    // messagesByLocale.forEach((messageInThisLang, lang) => {
+    //   // Needs Nodejs 22
+    //   const diff = allMessages.difference(messageInThisLang);
+    //   if (diff.size)
+    //     this.logger.warn(`FTL messages '${Array.from(diff).join(", ")}' don't exist the locale '${lang}'`);
+    // });
+
+    // Check miss 2: Check ids in HTML but not in ftl
     this.htmlMessages.forEach((msg) => {
       if (this.ignores.includes(msg))
         return;
 
-      this.ftlMessages.forEach((messages, locale) => {
-        if (!messages.has(msg)) {
-          logger.warn(`Missing message: ${styleText.blue(msg)} in locale: ${locale}`);
-        }
-      });
+      const missingLocales = [...this.ftlMessages.entries()]
+        .filter(([_, messages]) => !messages.has(msg))
+        .map(([locale]) => locale);
+      if (missingLocales.length > 0)
+        logger.warn(`I10N id ${styleText.blue(msg)} missing in locale: ${missingLocales.join(", ")}`);
     });
   }
 
@@ -223,7 +231,7 @@ export function processHTMLFile(
     }
 
     if (!allMessages.has(id)) {
-      logger.warn(`Missing FTL: ${styleText.blue(id)} in ${styleText.gray(filePath)}`);
+      logger.warn(`I10N id ${styleText.blue(id)} in path ${styleText.gray(filePath)} does not exist in any locale, skip renaming it.`);
       return match;
     }
 

--- a/packages/scaffold/src/core/builder/fluent.ts
+++ b/packages/scaffold/src/core/builder/fluent.ts
@@ -1,0 +1,215 @@
+import type { BaseNode, Message, MessageReference, Resource } from "@fluent/syntax";
+import type { BuildConfig } from "../../types/config.js";
+import { readFile, writeFile } from "node:fs/promises";
+import { basename, dirname } from "node:path";
+import { parse, serialize, Transformer } from "@fluent/syntax";
+import { move } from "fs-extra/esm";
+import styleText from "node-style-text";
+import { glob } from "tinyglobby";
+import { logger } from "../../utils/logger.js";
+import { toArray } from "../../utils/string.js";
+
+export default async function buildLocale(
+  dist: string,
+  namespace: string,
+  options: BuildConfig["fluent"],
+) {
+  const ignores = toArray(options.ignore);
+  const localeNames = await getLocales(dist);
+  const messageManager = new MessageManager(ignores);
+
+  // Process FTL files and add messages to the manager
+  await Promise.all(localeNames.map(async (locale) => {
+    const ftlPaths = await glob(`${dist}/addon/locale/${locale}/**/*.ftl`);
+    await Promise.all(ftlPaths.map(async (ftlPath) => {
+      const originalContent = await readFile(ftlPath, "utf-8");
+      const { messages, processedContent } = processFTLFile(originalContent, namespace, options.prefixFluentMessages);
+
+      // Add FTL messages for the current locale
+      messageManager.addMessages(locale, messages);
+
+      if (options.prefixFluentMessages) {
+        await writeFile(ftlPath, processedContent);
+      }
+
+      if (options.prefixLocaleFiles) {
+        const newPath = `${dirname(ftlPath)}/${namespace}-${basename(ftlPath)}`;
+        await move(ftlPath, newPath);
+        logger.debug(`Renamed FTL: ${ftlPath} → ${newPath}`);
+      }
+    }));
+  }));
+
+  // Process HTML files and add messages to the manager
+  const htmlPaths = await glob([`${dist}/addon/**/*.xhtml`, `${dist}/addon/**/*.html`]);
+  await Promise.all(htmlPaths.map(async (htmlPath) => {
+    const content = await readFile(htmlPath, "utf-8");
+    const { processedContent, foundMessages } = processHTMLFile(
+      content,
+      namespace,
+      messageManager.getFTLMessages(),
+      ignores,
+      htmlPath,
+    );
+
+    // Add all found HTML messages
+    messageManager.addMessages("html", foundMessages);
+
+    if (options.prefixFluentMessages) {
+      await writeFile(htmlPath, processedContent);
+    }
+  }));
+
+  // Validate that all HTML messages exist in all locales
+  messageManager.validateMessages();
+}
+
+export class MessageManager {
+  private ftlMessages: Map<string, Set<string>> = new Map();
+  private htmlMessages: Set<string> = new Set();
+  private ignores: string[];
+
+  constructor(ignores: string[]) {
+    this.ignores = ignores;
+  }
+
+  // Add a set of messages (FTL or HTML) for a specific locale or for HTML globally
+  addMessages(target: string | "html", messages: string[]) {
+    if (target === "html") {
+      messages.forEach(msg => this.htmlMessages.add(msg));
+    }
+    else {
+      let ftlLocaleMessages = this.ftlMessages.get(target);
+      if (!ftlLocaleMessages) {
+        ftlLocaleMessages = new Set();
+        this.ftlMessages.set(target, ftlLocaleMessages);
+      }
+      messages.forEach(msg => ftlLocaleMessages.add(msg));
+    }
+  }
+
+  // Validate that all HTML messages exist in all FTL locales
+  validateMessages() {
+    this.htmlMessages.forEach((msg) => {
+      if (this.ignores.includes(msg))
+        return;
+
+      this.ftlMessages.forEach((messages, locale) => {
+        if (!messages.has(msg)) {
+          logger.warn(`Missing message: ${styleText.blue(msg)} in locale: ${locale}`);
+        }
+      });
+    });
+  }
+
+  getFTLMessages(): Set<string> {
+    const allMessages = new Set<string>();
+    this.ftlMessages.forEach(messages => messages.forEach(msg => allMessages.add(msg)));
+    return allMessages;
+  }
+
+  // Get all FTL messages for a specific locale
+  getFTLMessagesByLocale(locale: string): Set<string> {
+    return this.ftlMessages.get(locale) || new Set();
+  }
+
+  // Get all HTML messages
+  getHTMLMessages(): Set<string> {
+    return this.htmlMessages;
+  }
+}
+
+// Step 1: Extract all locale folder names
+async function getLocales(dist: string): Promise<string[]> {
+  const localePaths = await glob(`${dist}/addon/locale/*`, { onlyDirectories: true });
+  return localePaths.map(p => basename(p));
+}
+
+// Parse and optionally prefix messages in an FTL file
+export function processFTLFile(
+  content: string,
+  namespace: string,
+  shouldPrefix: boolean,
+) {
+  const messages = extractMessages(content);
+  const processed = shouldPrefix ? transformFluent(content, namespace) : content;
+  return { messages, processedContent: processed };
+}
+
+// Scan HTML content for l10n references and apply namespace prefix
+export function processHTMLFile(
+  content: string,
+  namespace: string,
+  allMessages: Set<string>,
+  ignores: string[],
+  filePath: string,
+) {
+  const foundMessages = new Set<string>();
+
+  const L10N_PATTERN = new RegExp(`(data-l10n-id)="((?!${namespace})\\S*)"`, "g");
+  const processed = content.replace(L10N_PATTERN, (match, attr, id) => {
+    foundMessages.add(id);
+
+    if (ignores.includes(id)) {
+      logger.debug(`Skipped ignored ID: ${styleText.blue(id)} in ${styleText.gray(filePath)}`);
+      return match;
+    }
+
+    if (!allMessages.has(id)) {
+      logger.warn(`Missing FTL: ${styleText.blue(id)} in ${styleText.gray(filePath)}`);
+      return match;
+    }
+
+    return `${attr}="${namespace}-${id}"`;
+  });
+
+  return { processedContent: processed, foundMessages: [...foundMessages] };
+}
+
+// Fluent parsing and serialization helpers
+export function parseFluent(source: string): Resource {
+  return parse(source, {});
+}
+
+export function extractMessages(source: string): string[] {
+  return parseFluent(source)
+    .body
+    .filter(entry => entry.type === "Message")
+    .map(message => message.id.name);
+}
+
+export function serializeFluent(resource: Resource): string {
+  return serialize(resource, {});
+}
+
+// Prefix Fluent message IDs using a transformer
+export function transformFluent(source: string, prefix: string | false): string {
+  const resource = parseFluent(source);
+  new FluentTransformer(prefix).genericVisit(resource);
+  return serializeFluent(resource);
+}
+
+// Custom Fluent AST transformer to apply message ID prefix
+class FluentTransformer extends Transformer {
+  constructor(private readonly prefix: string | false) {
+    super();
+  }
+
+  private needsPrefix(name: string): boolean {
+    return !!this.prefix && !name.startsWith(this.prefix);
+  }
+
+  visitMessage(node: Message): BaseNode {
+    if (this.needsPrefix(node.id.name)) {
+      node.id.name = `${this.prefix}-${node.id.name}`;
+    }
+    return this.genericVisit(node);
+  }
+
+  visitMessageReference(node: MessageReference): BaseNode {
+    if (this.needsPrefix(node.id.name)) {
+      node.id.name = `${this.prefix}-${node.id.name}`;
+    }
+    return this.genericVisit(node);
+  }
+}

--- a/packages/scaffold/test/e2e/snap/dist/addon/locale/en-US/test-plugin-prefs.ftl
+++ b/packages/scaffold/test/e2e/snap/dist/addon/locale/en-US/test-plugin-prefs.ftl
@@ -1,3 +1,3 @@
 test-plugin-meaasge-1 = General Settings
-test-plugin-meaasge-2-message-1 = 
+test-plugin-meaasge-2-message-1 =
     .label = example

--- a/packages/scaffold/test/unit/fluent.test.ts
+++ b/packages/scaffold/test/unit/fluent.test.ts
@@ -80,7 +80,7 @@ describe("processHTMLFile", () => {
 
     expect(processedContent).toBe("<div data-l10n-id=\"missingMessage\"></div>");
     expect(foundMessages.includes("missingMessage")).toBe(true);
-    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Missing FTL:"));
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("does not exist in any locale, skip renaming it"));
   });
 
   it("should not modify the content if no matching messages are found", () => {
@@ -135,7 +135,7 @@ describe("message-manager", () => {
     messageManager.validateMessages();
 
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringMatching(/Missing message: .*goodbye.* in locale: fr/),
+      expect.stringMatching(/I10N id .*goodbye.* missing in locale: fr/),
     );
   });
 

--- a/packages/scaffold/test/unit/fluent.test.ts
+++ b/packages/scaffold/test/unit/fluent.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  MessageManager,
+  processFTLFile,
+  processHTMLFile,
+  transformFluent,
+} from "../../src/core/builder/fluent.js";
+import { logger } from "../../src/utils/logger.js";
+
+vi.mock("../../src/utils/logger.js");
+
+describe("transformFluent()", () => {
+  const input = `
+welcome = Welcome
+about = About { welcome }
+`;
+
+  it("should correctly transform message IDs", () => {
+    const result = transformFluent(input, "test");
+    expect(result).toMatch(/test-welcome = Welcome/);
+    expect(result).toMatch(/test-about = About \{ test-welcome \}/);
+  });
+});
+
+describe("processFTLFile()", () => {
+  it("should keep content unchanged when prefixing is disabled", () => {
+    const input = "message = Hello";
+    const { messages, processedContent } = processFTLFile(input, "test", false);
+
+    expect(messages).toEqual(["message"]);
+    expect(processedContent).toBe(input);
+  });
+
+  it("should handle empty content correctly", () => {
+    const { messages, processedContent } = processFTLFile("", "test", true);
+
+    expect(messages).toEqual([]);
+    expect(processedContent).toBe("");
+  });
+});
+
+describe("processHTMLFile", () => {
+  const namespace = "myNamespace";
+  const ignores = ["ignoredMessage"];
+  const allMessages = new Set(["validMessage1", "validMessage2"]);
+  const filePath = "path/to/file.html";
+
+  it("should replace data-l10n-id with namespace-prefixed ID", () => {
+    const inputContent = `<div data-l10n-id="validMessage1"></div>`;
+
+    const { processedContent, foundMessages } = processHTMLFile(inputContent, namespace, allMessages, ignores, filePath);
+
+    expect(processedContent).toBe("<div data-l10n-id=\"myNamespace-validMessage1\"></div>");
+    expect(foundMessages.includes("validMessage1")).toBe(true);
+  });
+
+  it("should skip ignored IDs", () => {
+    const inputContent = `<div data-l10n-id="ignoredMessage"></div>`;
+    const { processedContent, foundMessages } = processHTMLFile(inputContent, namespace, allMessages, ignores, filePath);
+
+    expect(processedContent).toBe("<div data-l10n-id=\"ignoredMessage\"></div>");
+    expect(foundMessages.includes("ignoredMessage")).toBe(true);
+    expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("Skipped ignored ID:"));
+  });
+
+  it("should warn when an FTL message is missing", () => {
+    const inputContent = `<div data-l10n-id="missingMessage"></div>`;
+
+    const { processedContent, foundMessages } = processHTMLFile(inputContent, namespace, allMessages, ignores, filePath);
+
+    expect(processedContent).toBe("<div data-l10n-id=\"missingMessage\"></div>");
+    expect(foundMessages.includes("missingMessage")).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Missing FTL:"));
+  });
+
+  it("should not modify the content if no matching messages are found", () => {
+    const inputContent = `<div data-l10n-id="validMessage3"></div>`;
+    const { processedContent, foundMessages } = processHTMLFile(inputContent, namespace, allMessages, ignores, filePath);
+
+    expect(processedContent).toBe("<div data-l10n-id=\"validMessage3\"></div>"); // No replacement
+    expect(foundMessages.includes("validMessage3")).toBe(true); // No message found
+  });
+});
+
+describe("message-manager", () => {
+  let messageManager: MessageManager;
+  const ignores = ["ignore"];
+
+  beforeEach(() => {
+    messageManager = new MessageManager(ignores);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should add FTL messages for a specific locale", () => {
+    const locale = "en";
+    const messages = ["welcome", "goodbye"];
+
+    messageManager.addMessages(locale, messages);
+
+    const ftlMessages = messageManager.getFTLMessagesByLocale(locale);
+
+    expect(ftlMessages.has("welcome")).toBe(true);
+    expect(ftlMessages.has("goodbye")).toBe(true);
+  });
+
+  it("should add HTML messages", () => {
+    const messages = ["about", "contact"];
+
+    messageManager.addMessages("html", messages);
+
+    const htmlMessages = messageManager.getHTMLMessages();
+
+    expect(htmlMessages.has("about")).toBe(true);
+    expect(htmlMessages.has("contact")).toBe(true);
+  });
+
+  it("should validate missing HTML messages in FTL locales", () => {
+    messageManager.addMessages("en", ["welcome", "goodbye"]);
+    messageManager.addMessages("fr", ["welcome"]);
+    messageManager.addMessages("html", ["welcome", "goodbye"]);
+
+    messageManager.validateMessages();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/Missing message: .*goodbye.* in locale: fr/),
+    );
+  });
+
+  it("should not trigger a warning when HTML messages are present in all FTL locales", () => {
+    messageManager.addMessages("en", ["welcome", "about"]);
+    messageManager.addMessages("fr", ["welcome", "about"]);
+    messageManager.addMessages("html", ["about", "welcome"]);
+
+    messageManager.validateMessages();
+
+    // No warnings should be logged for "about" and "welcome"
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("should return all FTL messages", () => {
+    messageManager.addMessages("en", ["welcome", "about"]);
+    messageManager.addMessages("fr", ["welcome"]);
+
+    const allMessages = messageManager.getFTLMessages();
+
+    expect(allMessages).toEqual(new Set(["welcome", "about"]));
+  });
+
+  it("should return an empty set when no FTL messages exist for a locale", () => {
+    messageManager.addMessages("en", ["welcome", "about"]);
+
+    const frMessages = messageManager.getFTLMessagesByLocale("fr");
+
+    expect(frMessages.size).toBe(0);
+  });
+
+  it("should return empty HTML messages if none have been added", () => {
+    const htmlMessages = messageManager.getHTMLMessages();
+
+    expect(htmlMessages.size).toBe(0);
+  });
+});

--- a/packages/scaffold/test/unit/fluent.test.ts
+++ b/packages/scaffold/test/unit/fluent.test.ts
@@ -10,14 +10,9 @@ vi.mock("../../src/utils/logger.js");
 
 describe("fluent-manager", () => {
   let manager: FluentManager;
-  const input = `
-welcome = Welcome
-about = About { welcome }
-`;
 
   beforeEach(() => {
     manager = new FluentManager();
-    manager.parse(input);
   });
 
   afterEach(() => {
@@ -26,6 +21,10 @@ about = About { welcome }
 
   describe("getMessages()", () => {
     it("should return all message IDs", () => {
+      manager.parse(`
+welcome = Welcome
+about = About { welcome }
+`);
       const messages = manager.getMessages();
       expect(messages).toEqual(["welcome", "about"]);
     });
@@ -33,10 +32,16 @@ about = About { welcome }
 
   describe("prefix()", () => {
     it("should prefix message IDs correctly", () => {
+      manager.parse(`
+welcome = Welcome
+about = About { welcome }
+test-prefixed = Test { welcome }
+`);
       manager.prefixMessages("test");
       expect(manager.serialize()).toBe([
         "test-welcome = Welcome",
         "test-about = About { test-welcome }",
+        "test-prefixed = Test { test-welcome }",
         "",
       ]
         .join("\n"));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
 
   packages/scaffold:
     dependencies:
+      '@fluent/syntax':
+        specifier: ^0.19.0
+        version: 0.19.0
       '@swc/core':
         specifier: ^1.11.16
         version: 1.11.16
@@ -746,6 +749,10 @@ packages:
 
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+
+  '@fluent/syntax@0.19.0':
+    resolution: {integrity: sha512-5D2qVpZrgpjtqU4eNOcWGp1gnUCgjfM+vKGE2y03kKN6z5EBhtx0qdRFbg8QuNNj8wXNoX93KJoYb+NqoxswmQ==}
+    engines: {node: '>=14.0.0', npm: '>=7.0.0'}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -4449,6 +4456,8 @@ snapshots:
       '@floating-ui/core': 1.6.9
 
   '@floating-ui/utils@0.2.9': {}
+
+  '@fluent/syntax@0.19.0': {}
 
   '@humanfs/core@0.19.1': {}
 


### PR DESCRIPTION
closes: #112 
resolve: https://github.com/windingwind/zotero-plugin-toolkit/issues/77