### PR TITLE
fix(build): add missing await for buildInProduction()

### DIFF
--- a/src/core/builder/index.ts
+++ b/src/core/builder/index.ts
@@ -42,7 +42,7 @@ export default class Build extends Base {
 
     if (process.env.NODE_ENV === "production") {
       this.logger.tip("Packing plugin", { space: 1 });
-      this.buildInProduction();
+      await this.buildInProduction();
     }
 
     await this.ctx.hooks.callHook("build:done", this.ctx);


### PR DESCRIPTION
`buildInProduction()` is an async method that packs the XPI and generates update.json. Without `await`, the build process completes before the XPI file is actually written, resulting in no XPI output in production builds.