### PR TITLE
fix: replace 'grey' with 'gray' in styleText call for Node.js compatibility

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -25,7 +25,7 @@ const SYMBOLS = {
   TIP: styleText("blue", "→"),
   ERROR: styleText("bgRed", " ERROR "),
   WARN: styleText("bgYellow", " WARN "),
-  DEBUG: styleText("grey", "⚙"),
+  DEBUG: styleText("gray", "⚙"),
   NONE: "",
 };
 


### PR DESCRIPTION
I discoverd this bug while working with [zotero-plugin-template](https://github.com/windingwind/zotero-plugin-template) after having upgraded to Node v25.7.0.

`npm start` crashed with the following error:

```
> zotero-plugin serve
node:util:209
      validateOneOf(key, 'format', ObjectKeys(inspect.colors));
      ^
TypeError [ERR_INVALID_ARG_VALUE]: The argument 'format' must be one of:  […] 'gray', […]. Received 'grey'
    at styleText (node:util:209:7)
    at Proxy.<anonymous> (file:///[…]/node_modules/zotero-plugin-scaffold/dist/shared/zotero-plugin-scaffold.qsx_2VJx.mjs:12:7)
    at file:///[…]/zotero-plugin-scaffold.qsx_2VJx.mjs:38:17
    at ModuleJob.run (node:internal/modules/esm/module_job:430:25)
    at async node:internal/modules/esm/loader:639:26
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5) {
  code: 'ERR_INVALID_ARG_VALUE'
}
```

The fix is obviously to use "gray" instead of "grey", so yeah :)
`pnpm run build` went smoothly obviously.