### PR TITLE
feat: skip headless setup when ZOTERO_SETUP_COMPLETE is set

### DIFF
--- a/src/core/tester/index.ts
+++ b/src/core/tester/index.ts
@@ -105,7 +105,7 @@ export default class Test extends Base {
   }
 
   async startZotero(): Promise<void> {
-    if (this.ctx.test.headless) {
+    if (this.ctx.test.headless && !process.env.ZOTERO_SETUP_COMPLETE) {
       await prepareHeadless();
     }
 


### PR DESCRIPTION
When action-setup-zotero has already completed Zotero setup (signaled by ZOTERO_SETUP_COMPLETE=true), skip the redundant headless preparation (Xvfb, deps, Zotero download) in the tester.

Closes #126