### PR TITLE
fix(docs): resolve floating-vue SSR error during VitePress build

### DIFF
--- a/docs/src/.vitepress/theme/index.ts
+++ b/docs/src/.vitepress/theme/index.ts
@@ -1,13 +1,14 @@
 import type { EnhanceAppContext } from "vitepress";
-// .vitepress/theme/index.ts
-import TwoslashFloatingVue from "@shikijs/vitepress-twoslash/client";
 import Theme from "vitepress/theme";
 
 import "@shikijs/vitepress-twoslash/style.css";
 
 export default {
   extends: Theme,
-  enhanceApp({ app }: EnhanceAppContext) {
-    app.use(TwoslashFloatingVue);
+  async enhanceApp({ app }: EnhanceAppContext) {
+    if (!import.meta.env.SSR) {
+      const { default: TwoslashFloatingVue } = await import("@shikijs/vitepress-twoslash/client");
+      app.use(TwoslashFloatingVue);
+    }
   },
 };


### PR DESCRIPTION
## Problem

`pnpm docs:build` produces `Cannot destructure property 'popperId' of 'undefined'` errors from `floating-vue` during SSR rendering.

## Root Cause

`@shikijs/vitepress-twoslash` registers `TwoslashFloatingVue` which depends on `floating-vue@5.2.2`, a library that does not support server-side rendering (SSR).

## Fix

In the VitePress theme (`docs/src/.vitepress/theme/index.ts`), load `TwoslashFloatingVue` only on the client side using a dynamic import guarded by `!import.meta.env.SSR`.